### PR TITLE
Call 'gpr_thd_options_set_joinable(&toptions);'to make threads joinable

### DIFF
--- a/lib/thread_pool.c
+++ b/lib/thread_pool.c
@@ -161,6 +161,7 @@ grpc_c_thread_pool_add (grpc_c_thread_pool_t *pool,
 	gcthread->gct_pool = pool;
 	gpr_mu_init(&gcthread->gct_lock);
 	gpr_thd_options toptions = gpr_thd_options_default();
+	gpr_thd_options_set_joinable(&toptions);
 	if (!gpr_thd_new(&gcthread->gct_thread, gc_thread_func, 
 			 (void *)gcthread, &toptions)) {
 	    gpr_log(GPR_ERROR, "Failed to create thread");


### PR DESCRIPTION
We should call the function `gpr_thd_options_set_joinable(&toptions)` to make the thread to be  joinable, otherwise the threads were DETACHED by default. And the threads will be collected by OS, we could not call pthread_join to collect them. If we do that , there will be a core dump.
Signed-off-by: Li Feng <lifeng68@huawei.com>