### PR TITLE
fix install protobuf prefix var from pfx to pfix

### DIFF
--- a/builddeps.sh
+++ b/builddeps.sh
@@ -18,7 +18,7 @@ cd ../../
 
 echo "Installing Protobuf"
 cd third_party/protobuf
-./autogen.sh && ./configure --prefix=${pfx} && make && sudo make prefix=${pfix} install
+./autogen.sh && ./configure --prefix=${pfix} && make && sudo make prefix=${pfix} install
 sudo ldconfig
 cd ../../
 


### PR DESCRIPTION
#37 lib search prefix incorrect

cause run make in protobuf-c produce error
> 'libprotobuf.la' has not been install in '/lib'
> 'libprotoc.la' has not been install in '/lib'